### PR TITLE
Update commonmark-java dependency to 0.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
 
-        <version.commonmark>0.15.1</version.commonmark>
+        <version.commonmark>0.18.1</version.commonmark>
         <version.junit>4.13.1</version.junit>
         <version.ossindex-maven-enforcer-rules>3.1.0</version.ossindex-maven-enforcer-rules>
     </properties>
@@ -86,12 +86,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.atlassian.commonmark</groupId>
+            <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
             <version>${version.commonmark}</version>
         </dependency>
         <dependency>
-            <groupId>com.atlassian.commonmark</groupId>
+            <groupId>org.commonmark</groupId>
             <artifactId>commonmark-test-util</artifactId>
             <version>${version.commonmark}</version>
             <scope>test</scope>

--- a/src/main/java/fr/brouillard/oss/commonmark/ext/notifications/NotificationBlockParser.java
+++ b/src/main/java/fr/brouillard/oss/commonmark/ext/notifications/NotificationBlockParser.java
@@ -54,7 +54,7 @@ public class NotificationBlockParser extends AbstractBlockParser {
 
 	@Override
 	public BlockContinue tryContinue(ParserState state) {
-        CharSequence fullLine = state.getLine();
+        CharSequence fullLine = state.getLine().getContent();
         CharSequence currentLine = fullLine.subSequence(state.getColumn() + state.getIndent(), fullLine.length());
 
 		Matcher matcher = NOTIFICATIONS_LINE.matcher(currentLine);
@@ -71,7 +71,7 @@ public class NotificationBlockParser extends AbstractBlockParser {
 
 		@Override
 		public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
-			CharSequence fullLine = state.getLine();
+			CharSequence fullLine = state.getLine().getContent();
 			CharSequence line = fullLine.subSequence(state.getColumn(), fullLine.length());
 			Matcher matcher = NOTIFICATIONS_LINE.matcher(line);
 			if (matcher.matches()) {


### PR DESCRIPTION
* Updated to 0.18.1

Also, Mathieu, could you please add a license file to the repository too? All files within have a license header so that's good, but most people looking at code on github will look for a license indication at the root of the repo or at the github page (I know I thought it was unlicensed before looking more closely). It might help with adoption of this useful little extension.