### PR TITLE
Remove git config using LF

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,10 +24,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set git to use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
       - name: Checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Since you are using an `ubuntu-latest` runner, LF is already applied. The only time you would need to use what you had previously is if you were using a `windows`-based runner, which would default to CRLF.